### PR TITLE
Fix package

### DIFF
--- a/minizinc-mode.el
+++ b/minizinc-mode.el
@@ -48,58 +48,58 @@
 (defvar font-lock-operator-face 'font-lock-operator-face)
 
 
-(setq minizinc-keywords
-      '("var" "constraint" "solve" "satisfy" "maximize"
-	"minimize" "output" "par" "of" "where" "ann"
-	"annotation" "any" "array" "function" "include"
-	"op" "predicate" "record" "test" "tuple" "type"))
+(defvar minizinc-keywords
+  '("var" "constraint" "solve" "satisfy" "maximize"
+    "minimize" "output" "par" "of" "where" "ann"
+    "annotation" "any" "array" "function" "include"
+    "op" "predicate" "record" "test" "tuple" "type"))
 
-(setq minizinc-types
-      '("float" "int" "bool" "string" "list" "tuple"))
+(defvar minizinc-types
+  '("float" "int" "bool" "string" "list" "tuple"))
 
-(setq minizinc-builtins
-      '("abort" "abs" "acosh" "array_intersect" "array_union"
-	"array1d" "array2d" "array3d" "array4d" "array5d"
-	"array6d" "asin" "assert" "atan" "bool2int" "card"
-	"ceil" "concat" "cos" "cosh" "dom" "dom_array"
-	"dom_size" "fix" "exp" "floor" "index_set"
-	"index_set_1of2" "index_set_2of2" "index_set_1of3"
-	"int2float" "is_fixed" "join" "lb" "lb_array"
-	"length" "ln" "log" "log2" "log10" "min" "max"
-	"pow" "product" "round" "set2array" "show" "show_int"
-	"show_float" "sin" "sinh" "sqrt" "sum" "tan" "tanh"
-	"trace" "ub" "ub_array"
-	))
-
-
-
-(setq minizinc-operators
-      (concat "<\\->\\|\\->\\|<-\\|\\\\/\\|xor\\|/\\\\\\|<\\|>="
-	      "\\|<=\\|==\\|!=\\|<\\|>\\|=\\|in\\|subset\\|union"
-	      "\\|superset\\|diff\\|symdiff\\|\\.\\.\\|intersect"
-	      "\\|++\\|+\\|-\\|*\\|/\\|div\\|mod"))
+(defvar minizinc-builtins
+  '("abort" "abs" "acosh" "array_intersect" "array_union"
+    "array1d" "array2d" "array3d" "array4d" "array5d"
+    "array6d" "asin" "assert" "atan" "bool2int" "card"
+    "ceil" "concat" "cos" "cosh" "dom" "dom_array"
+    "dom_size" "fix" "exp" "floor" "index_set"
+    "index_set_1of2" "index_set_2of2" "index_set_1of3"
+    "int2float" "is_fixed" "join" "lb" "lb_array"
+    "length" "ln" "log" "log2" "log10" "min" "max"
+    "pow" "product" "round" "set2array" "show" "show_int"
+    "show_float" "sin" "sinh" "sqrt" "sum" "tan" "tanh"
+    "trace" "ub" "ub_array"
+    ))
 
 
-(setq minizinc-keywords-regex
-      (regexp-opt minizinc-keywords 'words))
 
-(setq minizinc-types-regex
-      (regexp-opt minizinc-types 'words))
+(defvar minizinc-operators
+  (concat "<\\->\\|\\->\\|<-\\|\\\\/\\|xor\\|/\\\\\\|<\\|>="
+          "\\|<=\\|==\\|!=\\|<\\|>\\|=\\|in\\|subset\\|union"
+          "\\|superset\\|diff\\|symdiff\\|\\.\\.\\|intersect"
+          "\\|++\\|+\\|-\\|*\\|/\\|div\\|mod"))
 
-(setq minizinc-builtins-regex
-      (regexp-opt minizinc-builtins 'words))
 
-(setq minizinc-operators-regex
-      minizinc-operators)
+(defvar minizinc-keywords-regex
+  (regexp-opt minizinc-keywords 'words))
 
-(setq minizinc-font-lock-keywords
-      `(
-	("%.*" . font-lock-comment-face)
-	(,minizinc-builtins-regex . font-lock-builtin-face)
-	(,minizinc-types-regex . font-lock-type-face)
-	(,minizinc-keywords-regex . font-lock-keyword-face)
-	(,minizinc-operators-regex . font-lock-operator-face)
-	))
+(defvar minizinc-types-regex
+  (regexp-opt minizinc-types 'words))
+
+(defvar minizinc-builtins-regex
+  (regexp-opt minizinc-builtins 'words))
+
+(defvar minizinc-operators-regex
+  minizinc-operators)
+
+(defvar minizinc-font-lock-keywords
+  `(
+    ("%.*" . font-lock-comment-face)
+    (,minizinc-builtins-regex . font-lock-builtin-face)
+    (,minizinc-types-regex . font-lock-type-face)
+    (,minizinc-keywords-regex . font-lock-keyword-face)
+    (,minizinc-operators-regex . font-lock-operator-face)
+    ))
 
 
 (define-derived-mode minizinc-mode java-mode "MiniZinc mode"

--- a/minizinc-mode.el
+++ b/minizinc-mode.el
@@ -102,7 +102,7 @@
     (,minizinc-operators-regex . font-lock-operator-face)
     ))
 
-
+;;;###autoload
 (define-derived-mode minizinc-mode java-mode "MiniZinc mode"
   "Major mode for edigint minizinc source file."
   (setq font-lock-defaults '((minizinc-font-lock-keywords)))

--- a/minizinc-mode.el
+++ b/minizinc-mode.el
@@ -106,7 +106,7 @@
 (define-derived-mode minizinc-mode java-mode "MiniZinc mode"
   "Major mode for edigint minizinc source file."
   (setq font-lock-defaults '((minizinc-font-lock-keywords)))
-  (setq-local c-basic-offset 0)
+  (set (make-local-variable 'c-basic-offset) 0)
   (setq comment-start "%")
   (setq comment-end "")
   )

--- a/minizinc-mode.el
+++ b/minizinc-mode.el
@@ -34,6 +34,7 @@
 
 ;;; Code:
 
+(require 'cc-mode)
 
 ;; (defface font-lock-operator-face
 ;;   '((t :inherit font-lock-builtin-face))

--- a/minizinc-mode.el
+++ b/minizinc-mode.el
@@ -36,17 +36,21 @@
 
 (require 'cc-mode)
 
+(defgroup minizinc nil
+  "Major mode for MiniZinc code"
+  :group 'languages)
+
 ;; (defface font-lock-operator-face
 ;;   '((t :inherit font-lock-builtin-face))
 ;;   "Used for operators."
 ;;   :group 'font-lock-faces)
 
-(defface font-lock-operator-face
+(defface minizinc-operator-face
   '((t (:foreground "dark orange")))
   "Used for operators."
-  :group 'font-lock-faces)
+  :group 'minizinc)
 
-(defvar font-lock-operator-face 'font-lock-operator-face)
+(defvar minizinc-operator-face 'minizinc-operator-face)
 
 
 (defvar minizinc-keywords
@@ -99,7 +103,7 @@
     (,minizinc-builtins-regex . font-lock-builtin-face)
     (,minizinc-types-regex . font-lock-type-face)
     (,minizinc-keywords-regex . font-lock-keyword-face)
-    (,minizinc-operators-regex . font-lock-operator-face)
+    (,minizinc-operators-regex . minizinc-operator-face)
     ))
 
 ;;;###autoload


### PR DESCRIPTION
- Fix byte-compile warnings
- Fix for older Emacs
- Add autoload cookie for lazy loading
- Define package group
- Prepend package name to own face

There are following byte-compile warnings in original code.

```
minizinc-mode.el:51:7:Warning: assignment to free variable
    ‘minizinc-keywords’
minizinc-mode.el:57:7:Warning: assignment to free variable ‘minizinc-types’
minizinc-mode.el:60:7:Warning: assignment to free variable
    ‘minizinc-builtins’
minizinc-mode.el:76:7:Warning: assignment to free variable
    ‘minizinc-operators’
minizinc-mode.el:84:19:Warning: reference to free variable
    ‘minizinc-keywords’
minizinc-mode.el:83:7:Warning: assignment to free variable
    ‘minizinc-keywords-regex’
minizinc-mode.el:87:19:Warning: reference to free variable ‘minizinc-types’
minizinc-mode.el:86:7:Warning: assignment to free variable
    ‘minizinc-types-regex’
minizinc-mode.el:90:19:Warning: reference to free variable
    ‘minizinc-builtins’
minizinc-mode.el:89:7:Warning: assignment to free variable
    ‘minizinc-builtins-regex’
minizinc-mode.el:93:7:Warning: reference to free variable
    ‘minizinc-operators’
minizinc-mode.el:92:7:Warning: assignment to free variable
    ‘minizinc-operators-regex’
minizinc-mode.el:98:11:Warning: reference to free variable
    ‘minizinc-builtins-regex’
minizinc-mode.el:99:11:Warning: reference to free variable
    ‘minizinc-types-regex’
minizinc-mode.el:100:11:Warning: reference to free variable
    ‘minizinc-keywords-regex’
minizinc-mode.el:101:11:Warning: reference to free variable
    ‘minizinc-operators-regex’
minizinc-mode.el:95:7:Warning: assignment to free variable
    ‘minizinc-font-lock-keywords’

In minizinc-mode:
minizinc-mode.el:108:15:Warning: assignment to free variable ‘c-basic-offset’
```
