### PR TITLE
Add word boundaries in minizinc-operators

### DIFF
--- a/minizinc-mode.el
+++ b/minizinc-mode.el
@@ -101,11 +101,10 @@
 
 
 (defvar minizinc-operators
-  (concat "<\\->\\|\\->\\|<-\\|\\\\/\\|xor\\|/\\\\\\|<\\|>="
-          "\\|<=\\|==\\|!=\\|<\\|>\\|=\\|in\\|subset\\|union"
-          "\\|superset\\|diff\\|symdiff\\|\\.\\.\\|intersect"
-          "\\|++\\|+\\|-\\|*\\|/\\|div\\|mod"))
-
+  (concat "<\\->\\|\\->\\|<-\\|\\\\/\\|/\\\\\\|<\\|>=\\|<="
+          "\\|==\\|!=\\|>\\|++\\|+\\|-\\|*\\|/\\|\\.\\.\\|"
+          "=\\|\\<\\(superset\\|diff\\|symdiff\\|intersect"
+          "\\|div\\|mod\\|xor\\|in\\|subset\\|union\\)\\>"))
 
 (defvar minizinc-keywords-regex
   (regexp-opt minizinc-keywords 'words))


### PR DESCRIPTION
This fixes some highlighting of operators within comments, for example `in` in M**in**iz**in**c
